### PR TITLE
Fix the branch renaming in the devops pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ SGX-enabled hardware.
 # CI
 
 Azure Pipelines is what we currently use for CI. It has two separate Pipelines
-that run on PR and merges to master. You can see results for the PR and master
+that run on PR and merges to main. You can see results for the PR and main
 runs on
 [Azure's site](https://dev.azure.com/signal-testing/directory-testing/_build) or
 in GitHub's UI.

--- a/service/ci/azure-pipelines/master.yml
+++ b/service/ci/azure-pipelines/master.yml
@@ -3,12 +3,12 @@ name: test build without enclave rebuild
 pr:
   branches:
     include:
-      - master
+      - main
 
 trigger:
   branches:
     include:
-      - master
+      - main
       - "test-svc-*"
       - "test_svc_*"
 

--- a/service/ci/azure-pipelines/test_with_enclave_rebuild.yml
+++ b/service/ci/azure-pipelines/test_with_enclave_rebuild.yml
@@ -5,12 +5,12 @@ name: test with enclave rebuild
 pr:
   branches:
     include:
-    - master
+    - main
 
 trigger:
   branches:
     include:
-    - master
+    - main
     - "test-*"
     - "test_*"
     exclude:
@@ -22,7 +22,7 @@ schedules:
     displayName: "Daily test run"
     branches:
       include:
-      - master
+      - main
     always: true
 
 resources:


### PR DESCRIPTION
It looks like the signal team has recently renamed the Branch from `master` to `main`. 
This PR is to adjust the DevOps pipeline accordingly. 